### PR TITLE
Create zmanji.yaml to contain Discover button remapping patch.

### DIFF
--- a/src/versions/4.25.15875/libnickel.so.1.0.0.yaml/zmanji.yaml
+++ b/src/versions/4.25.15875/libnickel.so.1.0.0.yaml/zmanji.yaml
@@ -1,0 +1,13 @@
+Make Discover Button Point to Pocket:
+  - Enabled: yes
+  - Description: Remaps Discover button on bottom navbar to open pocket article list
+  - ReplaceBytes:
+      Base: "MainNavController::discover()"
+      Offset: 40
+      FindInstBLX:     {SymPLT: "DiscoverNavMixin::showLastStoreTab()"}
+      ReplaceInstBLX:  {SymPLT: "LibraryNavMixin::showPocketLibrary()"}
+  - ReplaceBytes:
+      Base: "MainNavController::discover()"
+      Offset: 106
+      FindInstBLX:     {SymPLT: "DiscoverNavMixin::storefront()"}
+      ReplaceInstBLX:  {SymPLT: "LibraryNavMixin::showPocketLibrary()"}

--- a/src/versions/4.25.15875/libnickel.so.1.0.0.yaml/zmanji.yaml
+++ b/src/versions/4.25.15875/libnickel.so.1.0.0.yaml/zmanji.yaml
@@ -1,6 +1,6 @@
 Make Discover Button Point to Pocket:
-  - Enabled: yes
-  - Description: Remaps Discover button on bottom navbar to open pocket article list
+  - Enabled: no
+  - Description: Remaps Discover button on bottom navbar to open Pocket article list
   - ReplaceBytes:
       Base: "MainNavController::discover()"
       Offset: 40


### PR DESCRIPTION
This adds `zmanji.yaml` for libnickel. It contains a single patch proposed by me which I use and find useful.

This remaps the discover button on the bottom navbar to open up the Pocket article list instead of the Kobo store.

It doesn't have to be accepted but I am putting it up here to share with the maintains and other users of the repository.