### PR TITLE
Kepub constant font sharpness

### DIFF
--- a/src/versions/4.34.20097/libnickel.so.1.0.0.yaml/geoffr.yaml
+++ b/src/versions/4.34.20097/libnickel.so.1.0.0.yaml/geoffr.yaml
@@ -407,7 +407,7 @@ ePub constant font sharpness:
   - FindBaseAddressString: "\0\0 -kobo-font-sharpness: %1;"
   - ReplaceString: {Offset: 3, Find: "-kobo-font-sharpness: %1", Replace: "-kobo-font-sharpness:0.2", MustMatchLength: yes}
 
-# MISSING: KePub constant font sharpness (not enough room for neutralizing the QString arg; we will probably need to patch that one out)
+# For KePub constant font sharpness, see another patch below.
 
 Un-Force user text-align in div,p tags in KePubs:
   - Enabled: no

--- a/src/versions/4.34.20097/libnickel.so.1.0.0.yaml/superjeng1.yaml
+++ b/src/versions/4.34.20097/libnickel.so.1.0.0.yaml/superjeng1.yaml
@@ -1,0 +1,19 @@
+# The following patch(es) were made by superjeng1
+
+KePub constant font sharpness:
+  - Enabled: no
+  - Description: |
+      With this patch the KePub reader will use a constant sharpness value of 0.2,
+      instead of the value set by the advanced font sharpness/weight slider. The
+      slider sharpness values range from -0.4(min.) to 0.2(max.), default -0.0666.
+    #     body { -kobo-font-sharpness: %1; -kobo-font-thickness: %2; text-rendering: %3; }\n
+    # --> body{-kobo-font-sharpness:0.0/*%1*/;-kobo-font-thickness:%2;text-rendering: %3;}\n
+  - FindReplaceString:
+      Find:    "body { -kobo-font-sharpness: %1; -kobo-font-thickness: %2; text-rendering: %3; }\n"
+      Replace: "body{-kobo-font-sharpness:0.0/*%1*/;-kobo-font-thickness:%2;text-rendering: %3;}\n"
+      MustMatchLength: yes
+  - ReplaceString: 
+      Offset: 5 
+      Find:    "-kobo-font-sharpness:0.0"
+      Replace: "-kobo-font-sharpness:0.2" # Replacement sharpness value
+      MustMatchLength: yes

--- a/src/versions/4.35.20400/libnickel.so.1.0.0.yaml/geoffr.yaml
+++ b/src/versions/4.35.20400/libnickel.so.1.0.0.yaml/geoffr.yaml
@@ -407,7 +407,7 @@ ePub constant font sharpness:
   - FindBaseAddressString: "\0\0 -kobo-font-sharpness: %1;"
   - ReplaceString: {Offset: 3, Find: "-kobo-font-sharpness: %1", Replace: "-kobo-font-sharpness:0.2", MustMatchLength: yes}
 
-# MISSING: KePub constant font sharpness (not enough room for neutralizing the QString arg; we will probably need to patch that one out)
+# For KePub constant font sharpness, see another patch below.
 
 Un-Force user text-align in div,p tags in KePubs:
   - Enabled: no

--- a/src/versions/4.35.20400/libnickel.so.1.0.0.yaml/superjeng1.yaml
+++ b/src/versions/4.35.20400/libnickel.so.1.0.0.yaml/superjeng1.yaml
@@ -1,0 +1,19 @@
+# The following patch(es) were made by superjeng1
+
+KePub constant font sharpness:
+  - Enabled: no
+  - Description: |
+      With this patch the KePub reader will use a constant sharpness value of 0.2,
+      instead of the value set by the advanced font sharpness/weight slider. The
+      slider sharpness values range from -0.4(min.) to 0.2(max.), default -0.0666.
+    #     body { -kobo-font-sharpness: %1; -kobo-font-thickness: %2; text-rendering: %3; }\n
+    # --> body{-kobo-font-sharpness:0.0/*%1*/;-kobo-font-thickness:%2;text-rendering: %3;}\n
+  - FindReplaceString:
+      Find:    "body { -kobo-font-sharpness: %1; -kobo-font-thickness: %2; text-rendering: %3; }\n"
+      Replace: "body{-kobo-font-sharpness:0.0/*%1*/;-kobo-font-thickness:%2;text-rendering: %3;}\n"
+      MustMatchLength: yes
+  - ReplaceString: 
+      Offset: 5 
+      Find:    "-kobo-font-sharpness:0.0"
+      Replace: "-kobo-font-sharpness:0.2" # Replacement sharpness value
+      MustMatchLength: yes


### PR DESCRIPTION
In `libnickel.so.1.0.0.yaml/geoffr.yaml`, constant font sharpness patch is missing for KePubs. He left a comment in the file which reads:

> MISSING: KePub constant font sharpness (not enough room for neutralizing the QString arg; we will probably need to patch that one out)

I don't quite understand it since I am able to do the patch and verify that it is actually working with screenshots. Have I missed anything? Also, I only edited version 4.34 and 4.35 because I have only tested these versions.